### PR TITLE
Travis: sudo: false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 python: 2.7
 cache:


### PR DESCRIPTION
* Apparently we're still getting a 'precise/sudo: required' build
  environment. Let's try not to.